### PR TITLE
Add .quatt-sniffer-ESP32S3.yaml for isolated Modbus sniffer PCB

### DIFF
--- a/.quatt-sniffer-ESP32S3.yaml
+++ b/.quatt-sniffer-ESP32S3.yaml
@@ -4,4 +4,4 @@ esp32:
     type: arduino
 
 substitutions:
-  uart_rx_pin: GPIO06
+  uart_rx_pin: GPIO06  ## isolated RS-485 transceiver

--- a/.quatt-sniffer-ESP32S3.yaml
+++ b/.quatt-sniffer-ESP32S3.yaml
@@ -1,0 +1,7 @@
+esp32:
+  board: esp32-s3-devkitm-1
+  framework:
+    type: arduino
+
+substitutions:
+  uart_rx_pin: GPIO06

--- a/.quatt-sniffer-HP1.yaml
+++ b/.quatt-sniffer-HP1.yaml
@@ -20,9 +20,9 @@ logger:
   level: VERBOSE
   logs:
     uart_debug: ERROR                   ## suppress log-messages from uart
-    modbus: DEBUG                        ## suppress log-messages from modbus
-    modbus_controller.sensor: DEBUG      ## suppress log-messages from modbus_controller.sensor
-    sensor: DEBUG                        ## suppress log-messages from modbus_controller
+    modbus: VERBOSE                        ## suppress log-messages from modbus
+    modbus_controller.sensor: VERBOSE      ## suppress log-messages from modbus_controller.sensor
+    sensor: VERBOSE                        ## suppress log-messages from modbus_controller
 
 
 # Configuration of UART with Quatt modbus connection-parameters

--- a/.quatt-sniffer-HP1.yaml
+++ b/.quatt-sniffer-HP1.yaml
@@ -21,7 +21,7 @@ logger:
   logs:
     uart_debug: ERROR                   ## suppress log-messages from uart
     modbus: WARN                        ## suppress log-messages from modbus
-    modbus_controller.sensor: WARN      ## suppress log-messages from modbus_controller.sensor
+    modbus_controller.sensor: DEBUG      ## suppress log-messages from modbus_controller.sensor
     sensor: WARN                        ## suppress log-messages from modbus_controller
 
 

--- a/.quatt-sniffer-HP1.yaml
+++ b/.quatt-sniffer-HP1.yaml
@@ -17,7 +17,7 @@ external_components:
 logger:
   #baud_rate: 0                         ## Turn off logging via UART (set baudrate to 0) in case the RS485 uses the onboard UART (tx/rx)
                                         ## However, in sniffer mode and with detached TX hardware trace this is not needed
-  level: DEBUG
+  level: VERBOSE
   logs:
     uart_debug: ERROR                   ## suppress log-messages from uart
     modbus: DEBUG                        ## suppress log-messages from modbus

--- a/.quatt-sniffer-HP1.yaml
+++ b/.quatt-sniffer-HP1.yaml
@@ -20,7 +20,7 @@ logger:
   level: DEBUG
   logs:
     uart_debug: ERROR                   ## suppress log-messages from uart
-    modbus: WARN                        ## suppress log-messages from modbus
+    modbus: DEBUG                        ## suppress log-messages from modbus
     modbus_controller.sensor: DEBUG      ## suppress log-messages from modbus_controller.sensor
     sensor: WARN                        ## suppress log-messages from modbus_controller
 

--- a/.quatt-sniffer-HP1.yaml
+++ b/.quatt-sniffer-HP1.yaml
@@ -22,7 +22,7 @@ logger:
     uart_debug: ERROR                   ## suppress log-messages from uart
     modbus: DEBUG                        ## suppress log-messages from modbus
     modbus_controller.sensor: DEBUG      ## suppress log-messages from modbus_controller.sensor
-    sensor: WARN                        ## suppress log-messages from modbus_controller
+    sensor: DEBUG                        ## suppress log-messages from modbus_controller
 
 
 # Configuration of UART with Quatt modbus connection-parameters

--- a/quatt-sniffer.yaml
+++ b/quatt-sniffer.yaml
@@ -28,7 +28,7 @@ packages:
   #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32.yaml   ## Uses GPIO23
   #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32S3.yaml ## Uses GPIO06 (MarcoW71 isolated modbus sniffer)
   #
-  HP1: github://MarcoW71/Quatt-sniffer/.quatt-sniffer-HP1.yaml ## Always needed
+  HP1: github://M10tech/Quatt-sniffer/.quatt-sniffer-HP1.yaml ## Always needed
   #HP2: github://M10tech/Quatt-sniffer/.quatt-sniffer-HP2.yaml
   ## Uncomment the line above in case you have a Quatt Duo (HP1+HP2)
   #

--- a/quatt-sniffer.yaml
+++ b/quatt-sniffer.yaml
@@ -28,7 +28,7 @@ packages:
   #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32.yaml   ## Uses GPIO23
   #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32S3.yaml ## Uses GPIO06 (MarcoW71 isolated modbus sniffer)
   #
-  HP1: github://M10tech/Quatt-sniffer/.quatt-sniffer-HP1.yaml ## Always needed
+  HP1: github://MarcoW71/Quatt-sniffer/.quatt-sniffer-HP1.yaml ## Always needed
   #HP2: github://M10tech/Quatt-sniffer/.quatt-sniffer-HP2.yaml
   ## Uncomment the line above in case you have a Quatt Duo (HP1+HP2)
   #

--- a/quatt-sniffer.yaml
+++ b/quatt-sniffer.yaml
@@ -26,8 +26,9 @@ packages:
   ## Uncomment one ESP-line below that represents your chipset
   #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32C3.yaml ## Uses GPIO20
   #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32.yaml   ## Uses GPIO23
+  #ESP: github://M10tech/Quatt-sniffer/.quatt-sniffer-ESP32S3.yaml ## Uses GPIO06 (MarcoW71 isolated modbus sniffer)
   #
-  HP1: github://M10tech/Quatt-sniffer/.quatt-sniffer-HP1.yaml ## Always needed
+  HP1: github://MarcoW71/Quatt-sniffer/.quatt-sniffer-HP1.yaml ## Always needed
   #HP2: github://M10tech/Quatt-sniffer/.quatt-sniffer-HP2.yaml
   ## Uncomment the line above in case you have a Quatt Duo (HP1+HP2)
   #


### PR DESCRIPTION
I successfully tested the isolated Modbus sniffer PCB containing a ESP32 S3 mini with the Quatt-sniffer ESPHome firmware